### PR TITLE
Make example app dependent on angular 1.4.0

### DIFF
--- a/example/bower.json
+++ b/example/bower.json
@@ -18,8 +18,8 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.2.0",
-    "angular-route": "~1.2.16",
+    "angular": "~1.4.0",
+    "angular-route": "~1.4.0",
     "angular-bootstrap": "~0.11.0",
     "ngstorage": "~0.3.0"
   },


### PR DESCRIPTION
Example app was broken because angular-tryton now depends on newer
version of angular.

Fixes #30
